### PR TITLE
Add feature "ignore-next-line" and remove indent between comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/Release
 node_modules
 
 package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -153,3 +153,106 @@ const expectedCode = [
 assert.equal(blocks[0].blocks[0].code, expectedCode);
 ```
 
+#### Can remove indent that changes between ignore comments
+
+Can remove indent that changed between the start and end comments, to allow smoother flow:
+
+```javascript
+const acquit = require('acquit');
+require('acquit-ignore')();
+
+var contents = [
+  'describe(\'test\', function() {',
+  '  it(\'works\', function(done) {',
+  '    // acquit:ignore:start',
+  '    const t = 1',
+  '    // acquit:ignore:end',
+  '    const a = 2',
+  '    // acquit:ignore:start',
+  '    setTimeout(function() {',
+  '      // acquit:ignore:end',
+  '      something.save()',
+  '      // acquit:ignore:start',
+  '      t.cb(() => {',
+  '        // acquit:ignore:end',
+  '        other.save()',
+  '        // acquit:ignore:start',
+  '      })',
+  '      // acquit:ignore:end',
+  '      s.cb(() => {',
+  '        another.save()',
+  '      })',
+  '      // acquit:ignore:start',
+  '    }, 0);',
+  '    // acquit:ignore:end',
+  '  });',
+  '});'
+].join('\n');
+
+const blocks = acquit.parse(contents);
+assert.equal(blocks.length, 1);
+assert.equal(blocks[0].blocks[0].contents, 'works');
+
+const expectedCode = [
+  'const a = 2',
+  'something.save()',
+  'other.save()',
+  's.cb(() => {',
+  '  another.save()',
+  '})'
+].join('\n');
+
+assert.equal(blocks[0].blocks[0].code, expectedCode);
+```
+
+Also if option `getIndentDifferenceFromNextLine` is `true` (which is the default), then the indent will also be gotten from the next line after the end comment:
+
+```javascript
+const acquit = require('acquit');
+require('acquit-ignore')({
+  getIndentDifferenceFromNextLine: true
+});
+
+var contents = [
+  'describe(\'test\', function() {',
+  '  it(\'works\', function(done) {',
+  '    // acquit:ignore:start',
+  '    const t = 1',
+  '    // acquit:ignore:end',
+  '    const a = 2',
+  '    // acquit:ignore:start',
+  '    setTimeout(function() {',
+  '    // acquit:ignore:end', // should get the indent from the next line
+  '      something.save()', // should get indent from here
+  '      // acquit:ignore:start',
+  '      t.cb(() => {',
+  '      // acquit:ignore:end', // should get the indent from the next line
+  '        other.save()', // should get indent from here
+  '        // acquit:ignore:start',
+  '      })',
+  '      // acquit:ignore:end',
+  '      s.cb(() => {',
+  '        another.save()',
+  '      })',
+  '      // acquit:ignore:start',
+  '    }, 0);',
+  '    // acquit:ignore:end',
+  '  });',
+  '});'
+].join('\n');
+
+const blocks = acquit.parse(contents);
+assert.equal(blocks.length, 1);
+assert.equal(blocks[0].blocks[0].contents, 'works');
+
+const expectedCode = [
+  'const a = 2',
+  'something.save()',
+  'other.save()',
+  's.cb(() => {',
+  '  another.save()',
+  '})'
+].join('\n');
+
+assert.equal(blocks[0].blocks[0].code, expectedCode);
+```

--- a/README.md
+++ b/README.md
@@ -256,3 +256,50 @@ const expectedCode = [
 
 assert.equal(blocks[0].blocks[0].code, expectedCode);
 ```
+
+#### Also supports a "ignore-next-line"
+
+Like eslint's `eslint-disable-next-line`, this package also supports a similar method:
+
+```javascript
+const acquit = require('acquit');
+require('acquit-ignore')();
+
+var contents = [
+  'describe(\'test\', function() {',
+  '  it(\'works\', function(done) {',
+  '    // acquit:ignore-next-line',
+  '    const t = 1',
+  '    const a = 2',
+  '    // acquit:ignore-next-line',
+  '    setTimeout(function() {',
+  '      something.save()',
+  '      // acquit:ignore-next-line',
+  '      t.cb(() => {',
+  '        other.save()',
+  '        // acquit:ignore-next-line',
+  '      })',
+  '      s.cb(() => {',
+  '        another.save()',
+  '      })',
+  '      // acquit:ignore-next-line',
+  '    }, 0);',
+  '  });',
+  '});'
+].join('\n');
+
+const blocks = acquit.parse(contents);
+assert.equal(blocks.length, 1);
+assert.equal(blocks[0].blocks[0].contents, 'works');
+
+const expectedCode = [
+  'const a = 2',
+  'something.save()',
+  'other.save()',
+  's.cb(() => {',
+  '  another.save()',
+  '})'
+].join('\n');
+
+assert.equal(blocks[0].blocks[0].code, expectedCode);
+```

--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ const OptionsType = new Archetype({
   end: {
     $type: 'string',
     $default: '// acquit:ignore:end'
+  },
+  getIndentDifferenceFromNextLine: {
+    $type: 'boolean',
+    $default: true
   }
 }).compile('OptionsType');
 
@@ -28,12 +32,98 @@ module.exports = function(parser, options) {
 
   options = new OptionsType(options || {});
 
-  const inlineRegexp = new RegExp('^[\\s]*' + options.start + '[\\s\\S]*?' +
-    options.end + '\n?', 'gm');
+  const startRegexp = new RegExp(`^[\\s]*${options.start}$`);
+  const endRegexp = new RegExp(`^[\\s]*${options.end}$`);
 
   parser.transform(/** @param {AcquitBlock} block */function(block) {
-    block.code = block.code.
-      replace(inlineRegexp, '');
+    const spacesRegexp = /^(\s*)/;
+
+    /** Output accumulator (to not modify block.code directly) */
+    let out = '';
+    /**
+     * States:
+     * 0: no ignore
+     * 1: ignore lines
+     */
+    let currentState = { state: 0, hadMatch: false };
+    /** Keeps track of the state from the previous line */
+    let lastLineState = { state: 0, hadMatch: false };
+
+    /** Sets which line-ending to use */
+    let lineEnd = '\n';
+
+    // determine original line endings
+    {
+      const matches = /(\r?\n)^/m.exec(block.code);
+
+      if (matches !== null) {
+       lineEnd = matches[0];
+      }
+    }
+
+    /** Stores the indent that should get removed */
+    let diffIndent = '';
+
+    for (let line of block.code.split(/\r?\n/)) {
+      // set the last line state
+      lastLineState.hadMatch = currentState.hadMatch;
+      lastLineState.state = currentState.state;      
+
+      let typeMatch;
+      switch (currentState.state) {
+        case 0:
+          typeMatch = startRegexp.exec(line);
+          if (typeMatch !== null) {
+            currentState.state = 1;
+          }
+          break;
+        case 1:
+          typeMatch = endRegexp.exec(line);
+          if (typeMatch !== null) {
+            currentState.state = 0;
+          }
+          break;
+        default:
+          throw new Error("Encountered invalid state");
+      }
+
+      currentState.hadMatch = typeMatch !== null;
+
+      // set the indent to remove, and use the next line after end comment if "options.getIndentDifferenceFromNextLine" is "true"
+      if (currentState.state === 0 && (typeMatch !== null || (options.getIndentDifferenceFromNextLine && lastLineState.state === 0 && lastLineState.hadMatch))) {
+        // get the start indent of the match
+        const _currentIndent = spacesRegexp.exec(line);
+        // change the regexp result into always being a string
+        const currentIndent = _currentIndent !== null ? _currentIndent[0] : '';
+
+        diffIndent = currentIndent.substring(0, currentIndent.length);
+      }
+
+      // add the current line to the output accumulator
+      if (currentState.state === 0 && typeMatch === null) {
+        // check if the indent to remove length matches the actual indent string, and only remove if matches
+        const sub = line.substring(0, diffIndent.length);
+        if (sub === diffIndent) {
+          line = line.substring(sub.length);
+        }
+
+        out = out + line + '\n'; // this will always add a trailing newline, will later be removed if needed
+      } 
+    }
+
+    // determine if the original code ended with a line break (and with which) and modify the output accordingly
+    {
+      // only take the last 5 characters to make matching easier
+      const lastChars = block.code.substring(block.code.length-5);
+
+      const matches = /(\r?\n)$/.exec(lastChars);
+
+      if (matches === null) {
+        out = out.substring(0, out.length - lineEnd.length);
+      }
+    }
+
+    block.code = out;
   });
 };
 
@@ -49,4 +139,5 @@ module.exports = function(parser, options) {
  * @typedef {Object} AcquitIgnoreOptions
  * @property {String} start
  * @property {String} end
+ * @property {boolean} getIndentDifferenceFromNextLine
  */

--- a/index.js
+++ b/index.js
@@ -13,6 +13,11 @@ const OptionsType = new Archetype({
   }
 }).compile('OptionsType');
 
+/**
+ * 
+ * @param {*} parser 
+ * @param {AcquitIgnoreOptions} options 
+ */
 module.exports = function(parser, options) {
   if (!parser) {
     parser = require('acquit');
@@ -26,8 +31,22 @@ module.exports = function(parser, options) {
   const inlineRegexp = new RegExp('^[\\s]*' + options.start + '[\\s\\S]*?' +
     options.end + '\n?', 'gm');
 
-  parser.transform(function(block) {
+  parser.transform(/** @param {AcquitBlock} block */function(block) {
     block.code = block.code.
       replace(inlineRegexp, '');
   });
 };
+
+/**
+ * @typedef {Object} AcquitBlock
+ * @property {String} type Test type (like "it")
+ * @property {String} contents Test name (like "should work")
+ * @property {Array.<String>} comments
+ * @property {String} code All the code inside the test (without outer indent)
+ */
+
+/**
+ * @typedef {Object} AcquitIgnoreOptions
+ * @property {String} start
+ * @property {String} end
+ */

--- a/index.js
+++ b/index.js
@@ -23,14 +23,11 @@ module.exports = function(parser, options) {
 
   options = new OptionsType(options || {});
 
-  const startsWithRegexp = new RegExp('^' + options.start + '[\\s\\S]*?' +
-    options.end + '\n?', 'g');
-  const inlineRegexp = new RegExp('[\\s]*' + options.start + '[\\s\\S]*?' +
-    options.end, 'g');
+  const inlineRegexp = new RegExp('^[\\s]*' + options.start + '[\\s\\S]*?' +
+    options.end + '\n?', 'gm');
 
   parser.transform(function(block) {
     block.code = block.code.
-      replace(startsWithRegexp, '').
       replace(inlineRegexp, '');
   });
 };

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -337,5 +337,48 @@ describe('acquit-ignore', function() {
   
       assert.equal(blocks[0].blocks[0].code, expectedCode);
     });
-  })
+  });
+
+  it('works with "nextLine"', function() {
+    const acquit = require('acquit');
+    require('acquit-ignore')();
+
+    var contents = [
+      'describe(\'test\', function() {',
+      '  it(\'works\', function(done) {',
+      '    // acquit:ignore-next-line',
+      '    const t = 1',
+      '    const a = 2',
+      '    // acquit:ignore-next-line',
+      '    setTimeout(function() {',
+      '      something.save()',
+      '      // acquit:ignore-next-line',
+      '      t.cb(() => {',
+      '        other.save()',
+      '        // acquit:ignore-next-line',
+      '      })',
+      '      s.cb(() => {',
+      '        another.save()',
+      '      })',
+      '      // acquit:ignore-next-line',
+      '    }, 0);',
+      '  });',
+      '});'
+    ].join('\n');
+
+    const blocks = acquit.parse(contents);
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].blocks[0].contents, 'works');
+
+    const expectedCode = [
+      'const a = 2',
+      'something.save()',
+      'other.save()',
+      's.cb(() => {',
+      '  another.save()',
+      '})'
+    ].join('\n');
+
+    assert.equal(blocks[0].blocks[0].code, expectedCode);
+  });
 });


### PR DESCRIPTION
This PR adds 2 features:
- a "ignore-next-line" option, analogous to how eslint has `eslint-disable-next-line`
- remove indent that changes between a `start` and `end` comment
  - also remove indent by using the line after the comment (if option is enabled)

Note: may contain eslint problems, but this project does not yet have eslint

Also removes the need for a `startsWithRegexp` and only uses one regexp for each match option

re https://github.com/Automattic/mongoose/pull/13156#discussion_r1133126687

uses a commit from #5 